### PR TITLE
Fix build for Windows with raw MSC

### DIFF
--- a/include/funchook.h
+++ b/include/funchook.h
@@ -39,7 +39,7 @@ extern "C" {
  * or libfunchook.so. Others are invisible.
  */
 #ifdef FUNCHOOK_EXPORTS
-#if defined(WIN32)
+#if defined(_WIN32)
 #define FUNCHOOK_EXPORT __declspec(dllexport)
 #elif defined(__GNUC__)
 #define FUNCHOOK_EXPORT __attribute__((visibility("default")))

--- a/src/funchook.c
+++ b/src/funchook.c
@@ -39,7 +39,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <limits.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
@@ -78,7 +78,7 @@ static void flush_instruction_cache(void *addr, size_t size)
 {
 #if defined __GNUC__
     __builtin___clear_cache((char*)addr, (char*)addr + size);
-#elif defined WIN32
+#elif defined _WIN32
     FlushInstructionCache(GetCurrentProcess(), addr, size);
 #else
 #error unsupported OS or compiler
@@ -230,12 +230,12 @@ static funchook_t *funchook_create_internal(void)
         num_entries_in_page = (page_size - offsetof(funchook_page_t, entries)) / sizeof(funchook_entry_t);
 #endif
         funchook_log(funchook,
-#ifdef WIN32
+#ifdef _WIN32
                      "  allocation_unit=%"PRIuPTR"\n"
 #endif
                      "  page_size=%"PRIuPTR"\n"
                      "  num_entries_in_page=%"PRIuPTR"\n",
-#ifdef WIN32
+#ifdef _WIN32
                      allocation_unit,
 #endif
                      page_size, num_entries_in_page);

--- a/src/funchook_internal.h
+++ b/src/funchook_internal.h
@@ -31,7 +31,7 @@
 #ifndef FUNCHOOK_INTERNAL_H
 #define FUNCHOOK_INTERNAL_H 1
 #include "funchook.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -104,7 +104,7 @@
 typedef struct {
     void *addr;
     size_t size;
-#ifdef WIN32
+#ifdef _WIN32
     DWORD protect;
 #endif
 } mem_state_t;

--- a/test/libfunchook_test.c
+++ b/test/libfunchook_test.c
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
 #define DLLEXPORT

--- a/test/libfunchook_test_noasm.c
+++ b/test/libfunchook_test_noasm.c
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
 #define DLLEXPORT

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -3,7 +3,7 @@
 #if defined(__linux__) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 #include <stdio.h>
@@ -14,7 +14,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <io.h>
 #define mode_t int
@@ -31,7 +31,7 @@
 #endif
 #include <funchook.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
 #define DLLEXPORT
@@ -133,7 +133,7 @@ enum load_type {
 static void *load_func(const char *module, const char *func)
 {
     void *addr;
-#ifdef WIN32
+#ifdef _WIN32
     HMODULE hMod = GetModuleHandleA(module);
         
     if (hMod == NULL) {
@@ -601,7 +601,7 @@ int main()
     TEST_FUNCHOOK_EXPECT_ERROR(x86_test_error_jump1, FUNCHOOK_ERROR_CANNOT_FIX_IP_RELATIVE);
     TEST_FUNCHOOK_EXPECT_ERROR(x86_test_error_jump2, FUNCHOOK_ERROR_FOUND_BACK_JUMP);
 
-#ifndef WIN32
+#ifndef _WIN32
     TEST_FUNCHOOK_INT(x86_test_call_get_pc_thunk_ax, LOAD_TYPE_NO_LOAD);
     TEST_FUNCHOOK_INT(x86_test_call_get_pc_thunk_bx, LOAD_TYPE_NO_LOAD);
     TEST_FUNCHOOK_INT(x86_test_call_get_pc_thunk_cx, LOAD_TYPE_NO_LOAD);

--- a/test/x86_test.S
+++ b/test/x86_test.S
@@ -61,7 +61,7 @@ label_2_1:
 #endif
 	ret
 
-#ifndef WIN32
+#ifndef _WIN32
 	.p2align 4,,15
 	.globl	x86_test_call_get_pc_thunk_ax
 x86_test_call_get_pc_thunk_ax:


### PR DESCRIPTION
Plain MSC defines `_WIN32` but not `WIN32` and this leads to build errors like this:

    Z:\home\kirr\src\tools\go\pygo-win\BuildTools\vc\tools\msvc\14.35.32215\bin\Hostx64\x64\cl.exe /c /nologo /O2 /W3 /GL /DNDEBUG /
    MD -DFUNCHOOK_EXPORTS -I. -I.\golang\_compat\windows -I3rdparty/funchook/include -I3rdparty/funchook/distorm/include -Ibuild\tem
    p.win-amd64-cpython-310\Release\. -Ibuild\temp.win-amd64-cpython-310\. -Ibuild\lib.win-amd64-cpython-310\. -Ibuild\. -Iz:\home\k
    irr\src\tools\go\pygo-win\BuildTools\vc\tools\msvc\14.35.32215\include -Iz:\home\kirr\src\tools\go\pygo-win\BuildTools\kits\10\i
    nclude\10.0.22000.0\shared -Iz:\home\kirr\src\tools\go\pygo-win\BuildTools\kits\10\include\10.0.22000.0\ucrt -Iz:\home\kirr\src\
    tools\go\pygo-win\BuildTools\kits\10\include\10.0.22000.0\um -Iz:\home\kirr\src\tools\go\pygo-win\BuildTools\kits\10\include\10.
    0.22000.0\winrt /Tc3rdparty/funchook/src/funchook.c /Fobuild\temp.win-amd64-cpython-310\Release\3rdparty/funchook/src/funchook.obj
    funchook.c
    3rdparty/funchook/src/funchook.c(61): error C2065: 'PATH_MAX': undeclared identifier
    3rdparty/funchook/src/funchook.c(61): error C2057: expected constant expression
    3rdparty/funchook/src/funchook.c(61): error C2466: cannot allocate an array of constant size 0
    3rdparty/funchook/src/funchook.c(84): fatal error C1189: #error:  unsupported OS or compiler
    error: command 'Z:\\home\\kirr\\src\\tools\\go\\pygo-win\\BuildTools\\vc\\tools\\msvc\\14.35.32215\\bin\\Hostx64\\x64\\cl.exe' f
    ailed with exit code 2

https://stackoverflow.com/a/74084728/9456786
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170

also CMake on recent VisualStudio is reported not to define `WIN32` as well

https://developercommunity.visualstudio.com/t/win32-not-defined/722576

-> Fix this by using `_WIN32` instead of `WIN32` in the sources everywhere.

P.S. Thanks a lot for funchook!