### PR TITLE
Fix PRIx64 being interpreted as C++11 user-defined literal suffix

### DIFF
--- a/test/unit_test.h
+++ b/test/unit_test.h
@@ -33,7 +33,7 @@ void unit_test_name(const char *name1, const char *name2);
 
 #define ASSERT_EQUAL_INT(expected, actual, funchook, ...) ASSERT_EQUAL_WITH_TYPE(int, "%d", expected, actual, funchook, __VA_ARGS__)
 #define ASSERT_EQUAL_LONG(expected, actual, funchook, ...) ASSERT_EQUAL_WITH_TYPE(long, "%ld", expected, actual, funchook, __VA_ARGS__)
-#define ASSERT_EQUAL_UINT64(expected, actual, funchook, ...) ASSERT_EQUAL_WITH_TYPE(uint64_t, "0x%"PRIx64, expected, actual, funchook, __VA_ARGS__)
+#define ASSERT_EQUAL_UINT64(expected, actual, funchook, ...) ASSERT_EQUAL_WITH_TYPE(uint64_t, "0x%" PRIx64, expected, actual, funchook, __VA_ARGS__)
 #define ASSERT_EQUAL_DOUBLE(expected, actual, funchook, ...) ASSERT_EQUAL_WITH_TYPE(double, "%f", expected, actual, funchook, __VA_ARGS__)
 
 #define ASSERT_TRUE(cond, funchook, ...) do { \


### PR DESCRIPTION
It seems to only happen when targeting Android:

```
In file included from /home/redacted/funchook/test/test_cpp.cpp:6:
/home/redacted/funchook/test/unit_test.h:36:100: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
#define ASSERT_EQUAL_UINT64(expected, actual, funchook, ...) ASSERT_EQUAL_WITH_TYPE(uint64_t, "0x%"PRIx64, expected, actual, funchook, __VA_ARGS__)
                                                                                                   ^
```
